### PR TITLE
Feature/add deeplink config

### DIFF
--- a/lib/distll-app-generator/commands/install.rb
+++ b/lib/distll-app-generator/commands/install.rb
@@ -14,8 +14,9 @@ command :install do |c|
   c.option '-s', '--scheme URL_Scheme/Facebook_suffix', 'The URL schemes or facebook suffix that his app can handle'
   c.option '-i', '--itunes ITUNES_URL', 'The app itunes url'
   c.option '-m', '--mixpanel MIXPANEL_TOKEN', 'The partner mixpanel token'
-  c.option '-B', '--branchio BRANCHIO_KEY', 'The branch io public key'
+  c.option '-B', '--branchiokey BRANCHIO_KEY', 'The branch io public key'
   c.option '-D', '--branchiodomain BRANCHIO_DOMAIN', 'The branch io domain'
+  c.option '-L', '--branchiolink BRANCHIO_LINK', 'The branch io link'
 
   c.option '', '--video VIDEO_URL', 'The url where the login video is downloaded'
 
@@ -51,11 +52,14 @@ command :install do |c|
     @mixpanel_token = options.mixpanel
     correct = check_param(@mixpanel_token,"MIXPANEL TOKEN")
 
-    @branch_key = options.branchio
+    @branchio_key = options.branchiokey
     correct = check_param(@branch_key,"BRANCHIO KEY")
 
     @branchio_domain = options.branchiodomain
     correct = check_param(@branchio_domain,"BRANCHIO DOMAIN")
+
+    @branchio_link = options.branchiolink
+    correct = check_param(@branchio_link,"BRANCHIO LINK")
 
     unless correct
       DistllAppGenerator::red 'Some parameters are missing. Fix them and run the script again'
@@ -104,7 +108,8 @@ command :install do |c|
               "IconSet":"'+@icon_set+'",
               "LoginVideoURL":"'+@video_url+'",
               "branch_app_domain":"'+@branchio_domain+'",
-              "branch_key":"'+@branch_key+'"
+              "branch_key":"'+@branchio_key+'",
+              "BranchLink":"'+@branchio_link+'"
           },
           "assets_url": "https://adminiu-media.s3.amazonaws.com/brand_images/'+@brand_id+'",
           "create_dir_for_plist": true

--- a/lib/distll-app-generator/commands/install.rb
+++ b/lib/distll-app-generator/commands/install.rb
@@ -14,6 +14,8 @@ command :install do |c|
   c.option '-s', '--scheme URL_Scheme/Facebook_suffix', 'The URL schemes or facebook suffix that his app can handle'
   c.option '-i', '--itunes ITUNES_URL', 'The app itunes url'
   c.option '-m', '--mixpanel MIXPANEL_TOKEN', 'The partner mixpanel token'
+  c.option '-B', '--branchio BRANCHIO_KEY', 'The branch io public key'
+  c.option '-D', '--branchiodomain BRANCHIO_DOMAIN', 'The branch io domain'
 
   c.option '', '--video VIDEO_URL', 'The url where the login video is downloaded'
 
@@ -48,6 +50,12 @@ command :install do |c|
 
     @mixpanel_token = options.mixpanel
     correct = check_param(@mixpanel_token,"MIXPANEL TOKEN")
+
+    @branch_key = options.branchio
+    correct = check_param(@branch_key,"BRANCHIO KEY")
+
+    @branchio_domain = options.branchiodomain
+    correct = check_param(@branchio_domain,"BRANCHIO DOMAIN")
 
     unless correct
       DistllAppGenerator::red 'Some parameters are missing. Fix them and run the script again'
@@ -94,7 +102,9 @@ command :install do |c|
               "Theme":"'+@theme_file+'",
               "TypeKit":"'+@type_kit+'",
               "IconSet":"'+@icon_set+'",
-              "LoginVideoURL":"'+@video_url+'"
+              "LoginVideoURL":"'+@video_url+'",
+              "branch_app_domain":"'+@branchio_domain+'",
+              "branch_key":"'+@branch_key+'"
           },
           "assets_url": "https://adminiu-media.s3.amazonaws.com/brand_images/'+@brand_id+'",
           "create_dir_for_plist": true

--- a/lib/distll-app-generator/plist.rb
+++ b/lib/distll-app-generator/plist.rb
@@ -21,6 +21,27 @@ module DistllAppGenerator
     return plist_text
   end
 
+  # Update Plist file with values on keys from info_hash
+  def self.update_entitlements entitlements, info_hash
+    return '' unless entitlements
+    return entitlements unless (info_hash)
+
+    info_hash.each_key do |k|
+        value = info_hash[k]
+        matches = entitlements.match /<key>#{k}<\/key>\s*<(.*?)>\s*/
+        
+        if matches
+            entitlements = entitlements.sub(matches[0], matches[0] + recursive_plist_value_for_value(value) + "\n")
+            DistllAppGenerator::blue ' match - ' + matches[0] unless $nolog
+        else
+            entitlements = entitlements.sub(/<\/dict>\s*<\/plist>/, "<key>" + k + "</key>\n" + recursive_plist_value_for_value(value) + "\n</dict></plist>")
+        end
+    end
+
+    return entitlements
+  end
+
+
   # Recursively create Plist Values for a given object
   def self.recursive_plist_value_for_value value
     return '' unless value != nil
@@ -66,4 +87,11 @@ module DistllAppGenerator
     main_plist.sub! '$(SRCROOT)/', ''
     return main_plist
   end
+
+  def self.get_main_entitlements_path(main_target)
+    main_entitlements = main_target.build_configurations[0].build_settings['CODE_SIGN_ENTITLEMENTS']
+    main_entitlements.sub! '$(SRCROOT)/', ''
+    return main_entitlements
+  end
+
 end

--- a/lib/distll-app-generator/targets.rb
+++ b/lib/distll-app-generator/targets.rb
@@ -101,6 +101,7 @@ module DistllAppGenerator
     main_target = proj.targets.first
     @target = create_target(proj, directory, target, assets, video)
 
+    # Create new info.plist
     main_plist = DistllAppGenerator::get_main_plist_path(main_target)
     main_plist_contents = File.read(directory + '/' + main_plist)
 
@@ -109,7 +110,22 @@ module DistllAppGenerator
     File.open(target_plist_path, 'w') do |f|
       f.write(plist_text)
     end
+
     DistllAppGenerator::green '  - ' + target + '-Info.plist Updated.' unless $nolog
+
+    # Update entitlements with applink
+    entitlements_path = DistllAppGenerator::get_main_entitlements_path(main_target)
+    return false if entitlements_path == nil
+    entitlements_contents = File.read(directory + '/' + entitlements_path)
+
+    associated_domain = 'applinks:' + info_keys["branch_app_domain"]
+    entitlements_text = DistllAppGenerator::update_plist entitlements_contents, {"com.apple.developer.associated-domains" => associated_domain}
+
+    File.open(entitlements_path, 'w') do |f|
+        f.write(entitlements_text)
+    end
+
+    DistllAppGenerator::green '  - ' + entitlements_path + ' Updated.' unless $nolog
 
 
     # Add Build Settings

--- a/lib/distll-app-generator/targets.rb
+++ b/lib/distll-app-generator/targets.rb
@@ -119,7 +119,7 @@ module DistllAppGenerator
     entitlements_contents = File.read(directory + '/' + entitlements_path)
 
     associated_domain = 'applinks:' + info_keys["branch_app_domain"]
-    entitlements_text = DistllAppGenerator::update_plist entitlements_contents, {"com.apple.developer.associated-domains" => associated_domain}
+    entitlements_text = DistllAppGenerator::update_entitlements entitlements_contents, {"com.apple.developer.associated-domains" => associated_domain}
 
     File.open(entitlements_path, 'w') do |f|
         f.write(entitlements_text)


### PR DESCRIPTION
Add deeplink configurations when we create a new target

ACCEPTANCE CRITERIA:
Target's info.plist file should have branch's keys:

- branch_app_domain : Branch.io's app domain
- branch_key : Branch.io's public key
- BranchLink: Branch.io's link to be shared

Distll's entitlements file should be updated on key com.apple.developer.associated-domains with applinks:<branch_app_domain>